### PR TITLE
Wrapping checkboxes in <label> tags

### DIFF
--- a/dta_uikit_base.theme
+++ b/dta_uikit_base.theme
@@ -1,6 +1,32 @@
 <?php
 
 /**
+ *
+ * Implements hook_preprocess_HOOK()
+ *
+ * This fiddles about with some elements to make them compatible with UI Kit.
+ *
+ **/
+
+/* Turns the 'wrapped label' setting on for checkboxes. */
+function dta_gov_au_preprocess_input__checkbox(&$variables) {
+ $variables['element']['#wrapped_label'] = TRUE;
+}
+
+function dta_gov_au_theme_suggestions_form_element_alter(array &$suggestions, array $variables) {
+ if ($variables['element']['#type'] === 'checkbox') {
+   $suggestions[] = 'form_element__wrapped';
+ }
+}
+
+function dta_gov_au_preprocess_form_element__wrapped(&$variables) {
+ $variables['label']['#theme'] = 'form_element_label__open';
+ $variables['label_open'] = $variables['label'];
+ unset($variables['label']);
+ $variables['title'] = $variables['element']['#title'];
+}
+
+/**
  * Implements hook_theme_suggestions_block_alter().
  *
  * As per https://www.drupal.org/docs/8/theming-drupal-8/creating-a-drupal-8-sub-theme-or-sub-theme-of-sub-theme

--- a/templates/form/form-element--wrapped.html.twig
+++ b/templates/form/form-element--wrapped.html.twig
@@ -1,0 +1,96 @@
+{#
+/**
+ * @file
+ * Theme override for a form element.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - errors: (optional) Any errors for this form element, may not be set.
+ * - prefix: (optional) The form element prefix, may not be set.
+ * - suffix: (optional) The form element suffix, may not be set.
+ * - required: The required marker, or empty if the associated form element is
+ *   not required.
+ * - type: The type of the element.
+ * - name: The name of the element.
+ * - label: A rendered label element.
+ * - label_display: Label display setting. It can have these values:
+ *   - before: The label is output before the element. This is the default.
+ *     The label includes the #title and the required marker, if #required.
+ *   - after: The label is output after the element. For example, this is used
+ *     for radio and checkbox #type elements. If the #title is empty but the
+ *     field is #required, the label will contain only the required marker.
+ *   - invisible: Labels are critical for screen readers to enable them to
+ *     properly navigate through forms but can be visually distracting. This
+ *     property hides the label for everyone except screen readers.
+ *   - attribute: Set the title attribute on the element to create a tooltip but
+ *     output no label element. This is supported only for checkboxes and radios
+ *     in \Drupal\Core\Render\Element\CompositeFormElementTrait::preRenderCompositeFormElement().
+ *     It is used where a visual label is not needed, such as a table of
+ *     checkboxes where the row and column provide the context. The tooltip will
+ *     include the title and required marker.
+ * - description: (optional) A list of description properties containing:
+ *    - content: A description of the form element, may not be set.
+ *    - attributes: (optional) A list of HTML attributes to apply to the
+ *      description content wrapper. Will only be set when description is set.
+ * - description_display: Description display setting. It can have these values:
+ *   - before: The description is output before the element.
+ *   - after: The description is output after the element. This is the default
+ *     value.
+ *   - invisible: The description is output after the element, hidden visually
+ *     but available to screen readers.
+ * - disabled: True if the element is disabled.
+ * - title_display: Title display setting.
+ *
+ * @see template_preprocess_form_element()
+ */
+#}
+{%
+  set classes = [
+    'js-form-item',
+    'form-item',
+    'js-form-type-' ~ type|clean_class,
+    'form-item-' ~ name|clean_class,
+    'js-form-item-' ~ name|clean_class,
+    title_display not in ['after', 'before'] ? 'form-no-label',
+    disabled == 'disabled' ? 'form-disabled',
+    errors ? 'form-item--error',
+  ]
+%}
+{%
+  set description_classes = [
+    'description',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+<div{{ attributes.addClass(classes) }} xmlns="http://www.w3.org/1999/html">
+  {{ label_open }}
+  {% if title_display == 'before' %}
+    <span class="au-control-input__text">{{ title }}</span>
+  {% endif %}
+  {% if prefix is not empty %}
+    <span class="field-prefix">{{ prefix }}</span>
+  {% endif %}
+  {% if description_display == 'before' and description.content %}
+    <div{{ description.attributes }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+  {{ children }}
+  {% if suffix is not empty %}
+    <span class="field-suffix">{{ suffix }}</span>
+  {% endif %}
+  {% if label_display == 'after' %}
+    <span class="au-control-input__text">{{ title }}</span>
+  {% endif %}
+  </label>
+  {% if errors %}
+    <div class="form-item--error-message">
+      {{ errors }}
+    </div>
+  {% endif %}
+  {% if description_display in ['after', 'invisible'] and description.content %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+</div>

--- a/templates/form/form-element-label--open.html.twig
+++ b/templates/form/form-element-label--open.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Theme override for a form element label.
+ *
+ * Available variables:
+ * - title: The label's text.
+ * - title_display: Elements title_display setting.
+ * - required: An indicator for whether the associated form element is required.
+ * - attributes: A list of HTML attributes for the label.
+ *
+ * @see template_preprocess_form_element_label()
+ */
+#}
+{%
+  set classes = [
+    title_display == 'after' ? 'option',
+    title_display == 'invisible' ? 'visually-hidden',
+    required ? 'js-form-required',
+    required ? 'form-required',
+    'au-control-input',
+  ]
+%}
+{% if title is not empty or required -%}
+  <label{{ attributes.addClass(classes) }}>
+{%- endif %}

--- a/templates/form/input--checkbox.html.twig
+++ b/templates/form/input--checkbox.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+ /**
+  * @TODO: Add templating to add the correct classes via a preprocess function.
+  * They need to be based on the eventual output of this, such as a button
+  * (.au-btn), or a text field (.au-text-input).
+#}
+
+{% set classes = ['au-control-input__input'] %}
+
+<input{{ attributes.addClass(classes) }} />{{ children }}


### PR DESCRIPTION
This commit updates checkboxes to wrap them with `<label>` tags:
 - Adds several theme functions.
 - `form-element--wrapped.html.twig` template.
 - `form-element-label--open.html.twig` template.
 - `input--checkbox.html.twig` template.